### PR TITLE
clearing directory

### DIFF
--- a/ansible/roles/magento/tasks/main.yml
+++ b/ansible/roles/magento/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: clear directory before magento install
+  become: yes
+  become_method: sudo
+  shell: rm -rf /var/www/magento2/*
+
 - name: Install magento
   become: yes
   become_method: sudo


### PR DESCRIPTION
after vagrant destroy...in your src directory there is a lot of messy files. And they couse magento2 installation an error.
you can also use "state=absent" do clear the directory.

also you can consider not to use sudo in composer commands